### PR TITLE
chore: use public ethereum_ssz and ethereum_serde_utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
 tree_hash = { git = "https://github.com/KolbyML/tree_hash.git", rev = "8aaf8bb4184148768d48e2cfbbdd0b95d1da8730" }
-ethereum_ssz = { git = "https://github.com/KolbyML/ethereum_ssz.git", rev = "364a2d93229e638b72c99186cbc2a56590585151" }
-ethereum_serde_utils = { git = "https://github.com/KolbyML/ethereum_serde_utils.git", rev = "b0f9fcf3ed6a983561925f1b520a725cfe2191f2" }
+ethereum_serde_utils = "0.5"
+ethereum_ssz = "0.5"
 serde = "1.0.0"
 serde_derive = "1.0.0"
 typenum = "1.12.0"


### PR DESCRIPTION
In case you want to make trin depend on your repos, as you are more likely to maintain it in the long term.